### PR TITLE
chore(mixin): update to use descriptor variable.

### DIFF
--- a/src/Mixin/mixin.ts
+++ b/src/Mixin/mixin.ts
@@ -13,7 +13,7 @@ export function Mixin(result: any, source: any, overwrite: boolean = true) {
     }
 
     const descriptor = Object.getOwnPropertyDescriptor(source, name);
-    Object.defineProperty(result, name, result);
+    Object.defineProperty(result, name, descriptor);
   }
 
   return result;


### PR DESCRIPTION
I updated the code to use the `descriptor` when defining the object property. Assuming this was missed.